### PR TITLE
make overwriting optional, simplify path syntax by os.path.join

### DIFF
--- a/File-Text-Capitalizer/text_capitalize.py
+++ b/File-Text-Capitalizer/text_capitalize.py
@@ -4,29 +4,36 @@
 import os
 
 
-def bulk_rename(path):
+def bulk_rename(path, overwrite=True):
     files = os.listdir(path)
     for user_file in files:
         if os.path.splitext(user_file)[1] == ".txt":
             capitalize_list = []
 
             # first reading txt line and captializing it and saving sentences in list
-            with open(f"{path}{user_file}", "r+") as f:
-                j = f.readlines()
+            user_file_path = os.path.join(path, user_file)
+            with open(user_file_path, "r+") as f_in:
+                j = f_in.readlines()
                 for line in j:
                     capitalize_line = line.capitalize()
                     capitalize_list.append(capitalize_line)
-
+            f_in.close()
+            
+            if overwrite:
+                out_file_path = user_file_path
+            else:
+                out_file_path = os.path.splitext(user_file)[0] + "_new"+ os.path.splitext(user_file)[1]
             # resetting txt file so that we can append our capitalize txt file
-            with open(f"{path}{user_file}", "w") as f:
-                f.write("")
+            with open(out_file_path, "w") as f_out:
+                f_out.write("")
 
             # writing capitalize sentences into txt file
-            with open(f"{path}{user_file}", "a") as f:
+            with open(out_file_path, "a") as f_out:
                 for sentence in capitalize_list:
-                    f.write(sentence)
+                    f_out.write(sentence)
 
 
 if __name__ == '__main__':
     path = input("Enter the path of txt files: ")
-    bulk_rename(path)
+    ow = input("Overwrite existing files? Type Yes")
+    bulk_rename(path, ow == "Yes")

--- a/File-Text-Capitalizer/thezenofpython.txt
+++ b/File-Text-Capitalizer/thezenofpython.txt
@@ -1,0 +1,20 @@
+# the zen of python
+beautiful is better than ugly.
+explicit is better than implicit.
+simple is better than complex.
+complex is better than complicated.
+flat is better than nested.
+sparse is better than dense.
+readability counts.
+special cases aren't special enough to break the rules.
+although practicality beats purity.
+errors should never pass silently.
+unless explicitly silenced.
+in the face of ambiguity, refuse the temptation to guess.
+there should be one-- and preferably only one --obvious way to do it.
+although that way may not be obvious at first unless you're dutch.
+now is better than never.
+although never is often better than *right* now.
+if the implementation is hard to explain, it's a bad idea.
+if the implementation is easy to explain, it may be a good idea.
+namespaces are one honking great idea -- let's do more of those!

--- a/File-Text-Capitalizer/thezenofpython_new.txt
+++ b/File-Text-Capitalizer/thezenofpython_new.txt
@@ -1,0 +1,20 @@
+# the zen of python
+Beautiful is better than ugly.
+Explicit is better than implicit.
+Simple is better than complex.
+Complex is better than complicated.
+Flat is better than nested.
+Sparse is better than dense.
+Readability counts.
+Special cases aren't special enough to break the rules.
+Although practicality beats purity.
+Errors should never pass silently.
+Unless explicitly silenced.
+In the face of ambiguity, refuse the temptation to guess.
+There should be one-- and preferably only one --obvious way to do it.
+Although that way may not be obvious at first unless you're dutch.
+Now is better than never.
+Although never is often better than *right* now.
+If the implementation is hard to explain, it's a bad idea.
+If the implementation is easy to explain, it may be a good idea.
+Namespaces are one honking great idea -- let's do more of those!


### PR DESCRIPTION
The following changes are made:

- user has to type `Yes` to overwrite existing files, otherwise a copy is made with "_new" suffix.
- System independent usage of relative paths: I replaced the f strings to `os.path.join` so that the user can type a relative path such as `.` so that the system's path delimiter `\` (Windows) or `/` (Linux) is automatically added.
- An example text is included.
